### PR TITLE
Update enable.sh

### DIFF
--- a/scripts/enable.sh
+++ b/scripts/enable.sh
@@ -77,7 +77,7 @@ else
     compose_up="false"
 fi
 
-curl -L https://github.com/docker/fig/releases/download/1.1.0-rc2/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
+curl -L https://github.com/docker/compose/releases/download/1.1.0-rc2/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
 chmod +x /usr/local/bin/docker-compose
 
 if [ "$compose_up" != "false" ]; then


### PR DESCRIPTION
It looks like with the release of 1.1.0, fig was renamed to compose which also resulted in them changing the repository name. Though traffic is automatically redirected, I thought it would be a good idea to update the repository link with the new name to avoid confusion.