### PR TITLE
Update install.sh and disable.sh

### DIFF
--- a/scripts/disable.sh
+++ b/scripts/disable.sh
@@ -25,7 +25,7 @@ if [ $distrib_id == "" ]; then
 	exit 1
 elif [ $distrib_id == "Ubuntu" ]; then
 	echo "This is Ubuntu."
-    service docker.io stop
+    service docker stop
     #update-rc.d docker.io off ?
 elif [ $distrib_id == "CoreOS" ]; then
 	echo "This is CoreOS."

--- a/scripts/dockerlib.sh
+++ b/scripts/dockerlib.sh
@@ -16,19 +16,33 @@
 # limitations under the License.
 #--------------------------------------------------------------------------
 
-set -e
+file_name=${0##*/}
 
-source ./dockerlib.sh
+timestamp() {
+    date +"%Y-%m-%d %H:%M:%S"
+}
 
-stop_docker_service() {
-    log "Stopping docker service"
+log() {
+    echo "$file_name $(timestamp): $1"
+}
 
-    if [ $distrib_id == "Ubuntu" ]; then
-	service docker stop
-    elif [ $distrib_id == "CoreOS" ]; then
-	systemctl stop docker
+is_supported_distro() {
+    [[ $1 == "CoreOS" || $1 == "Ubuntu" ]]
+}
+
+validate_distro() {
+    distrib_id=$(awk -F'=' '{if($1=="DISTRIB_ID")print $2; }' /etc/*-release);
+
+    if [ $distrib_id == "" ]; then
+	log "Error reading DISTRIB_ID"
+	exit 1
+    fi
+
+    if is_supported_distro $distrib_id; then 
+	log "OS $distrib_id is supported."
+    else
+	log "OS $distrib_id is NOT supported."
+	exit 1;
     fi
 }
 
-validate_distro
-stop_docker_service

--- a/scripts/dockerlib.sh
+++ b/scripts/dockerlib.sh
@@ -30,15 +30,19 @@ is_supported_distro() {
     [[ $1 == "CoreOS" || $1 == "Ubuntu" ]]
 }
 
+get_distro() {
+    echo $(awk -F'=' '{if($1=="DISTRIB_ID")print $2; }' /etc/*-release)
+}
+
 validate_distro() {
-    distrib_id=$(awk -F'=' '{if($1=="DISTRIB_ID")print $2; }' /etc/*-release);
+    distrib_id=$(get_distro)
 
     if [ $distrib_id == "" ]; then
 	log "Error reading DISTRIB_ID"
 	exit 1
     fi
 
-    if is_supported_distro $distrib_id; then 
+    if is_supported_distro $distrib_id; then
 	log "OS $distrib_id is supported."
     else
 	log "OS $distrib_id is NOT supported."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -62,14 +62,7 @@ cat $SCRIPT_DIR/running.status.json | sed s/@@DATE@@/$(date -u +%FT%TZ)/ > $stat
 echo "Installing Docker..."
 
 if [ $distrib_id == "Ubuntu" ]; then
-    export DEBIAN_FRONTEND=noninteractive
-    apt-get update
-    apt-get install -y -q linux-image-extra-$(uname -r) apt-transport-https
-    echo deb https://get.docker.com/ubuntu docker main > /etc/apt/sources.list.d/docker.list
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
-    sleep 3
-    apt-get update
-    apt-get install -y -q lxc-docker
+    wget -qO- https://get.docker.com/ | sh
 elif [ $distrib_id == "CoreOS" ]; then
     echo "Copy /usr/lib/systemd/system/docker.service --> /etc/systemd/system/"
     cp /usr/lib/systemd/system/docker.service /etc/systemd/system/

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -20,17 +20,35 @@ set -eu
 set -o pipefail
 IFS=$'\n\t'
 
+file_name=${0##*/}
+
+timestamp() {
+    date +"%Y-%m-%d %H:%M:%S"
+}
+
+log() {
+    echo "$file_name $(timestamp): $1"
+}
+
+supported_distro() {
+    [ $1 == "CoreOS" || $1 == "Ubuntu" ]
+}
+
 SCRIPT_DIR=$(cd $(dirname $0); pwd)
 
 distrib_id=$(awk -F'=' '{if($1=="DISTRIB_ID")print $2; }' /etc/*-release);
+log "OS is $distrib_id"
+
+if [ $distrib_id == "CoreOS" ]; then
+    type python >/dev/null 2>&1 || { export PATH=$PATH:/usr/share/oem/python/bin/; }
+    type python >/dev/null 2>&1 || { echo >&2 "Python is required but it's not installed."; exit 1; }
+fi
 
 if [ $distrib_id == "" ]; then
     echo "Error reading DISTRIB_ID"
     exit 1
 elif [ $distrib_id == "Ubuntu" ]; then
-    echo "This is Ubuntu."
 elif [ $distrib_id == "CoreOS" ]; then
-    echo "This is CoreOS."
     type python >/dev/null 2>&1 || { export PATH=$PATH:/usr/share/oem/python/bin/; }
     type python >/dev/null 2>&1 || { echo >&2 "Python is required but it's not installed."; exit 1; }
 else


### PR DESCRIPTION
install.sh now uses the official docker method of installation by
invoking the content of get.docker.com

disable.sh was not working because the service name had changed from
docker.io to docker