### PR TITLE
Update install.sh and disable.sh

### DIFF
--- a/scripts/disable.sh
+++ b/scripts/disable.sh
@@ -25,7 +25,7 @@ if [ $distrib_id == "" ]; then
 	exit 1
 elif [ $distrib_id == "Ubuntu" ]; then
 	echo "This is Ubuntu."
-    service docker.io stop
+    service docker stop
     #update-rc.d docker.io off ?
 elif [ $distrib_id == "CoreOS" ]; then
 	echo "This is CoreOS."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -62,14 +62,7 @@ cat $SCRIPT_DIR/running.status.json | sed s/@@DATE@@/$(date -u +%FT%TZ)/ > $stat
 echo "Installing Docker..."
 
 if [ $distrib_id == "Ubuntu" ]; then
-    export DEBIAN_FRONTEND=noninteractive
-    apt-get update
-    apt-get install -y -q linux-image-extra-$(uname -r) apt-transport-https
-    echo deb https://get.docker.com/ubuntu docker main > /etc/apt/sources.list.d/docker.list
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
-    sleep 3
-    apt-get update
-    apt-get install -y -q lxc-docker
+    wget -qO- https://get.docker.com/ | sh
 elif [ $distrib_id == "CoreOS" ]; then
     echo "Copy /usr/lib/systemd/system/docker.service --> /etc/systemd/system/"
     cp /usr/lib/systemd/system/docker.service /etc/systemd/system/


### PR DESCRIPTION
install.sh now uses the official docker method of installation by
invoking the content of get.docker.com

disable.sh was not working because the service name had changed from
docker.io to docker