### PR TITLE
Fix enable.sh on CoreOS

### DIFF
--- a/scripts/enable.sh
+++ b/scripts/enable.sh
@@ -77,9 +77,6 @@ else
     compose_up="false"
 fi
 
-curl -L https://github.com/docker/compose/releases/download/1.1.0-rc2/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
-chmod +x /usr/local/bin/docker-compose
-
 if [ "$compose_up" != "false" ]; then
     echo "composing:"
     echo $compose_up | yaml_dump
@@ -91,7 +88,6 @@ if [ "$compose_up" != "false" ]; then
 else
     echo "No compose args, not starting anything"
 fi
-
 
 if [ -n "$(cat $config | json_val \
     '["runtimeSettings"][0]["handlerSettings"]["publicSettings"]["installonly"]' \

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -76,3 +76,17 @@ azureuser=$(grep -Eo '<UserName>.+</UserName>' /var/lib/waagent/ovf-env.xml | aw
 sed -i -r "s/^docker:x:[0-9]+:$/&$azureuser/" /etc/group
 
 echo "Done Installing Docker"
+
+echo "Installing Docker Compose..."
+
+if [ $distrib_id == "CoreOS" ]; then
+    compose_dir=/opt/bin
+    mkdir -p $compose_dir
+else
+    compose_dir=/usr/local/bin
+fi
+
+curl -L https://github.com/docker/compose/releases/download/1.2.0/docker-compose-`uname -s`-`uname -m` > $compose_dir/docker-compose
+chmod +x $compose_dir/docker-compose
+
+echo "Done installing Docker Compose"


### PR DESCRIPTION
I spoke briefly with robszumski in the #coreos channel on
Freenode.  He suggested the appropriate place to install Docker Compose
was /opt/bin.  This directory doesn't exist by default on CoreOS so this
change includes creation of the directory.