### PR TITLE
Fix cert rewrite on VM reboot

### DIFF
--- a/scripts/disable.sh
+++ b/scripts/disable.sh
@@ -17,14 +17,9 @@
 #--------------------------------------------------------------------------
 
 set -e
-source ./dockerlib.sh
-exec >> $LOG_FILE 2>&1
+script_dir=$(cd $(dirname $0); pwd)
+source $script_dir/dockerlib.sh
+exec >> $log_file 2>&1
 
 validate_distro
-
-log "Stopping docker service"
-if [[ $DISTRO == "Ubuntu" ]]; then
-    service docker stop
-elif [[ $DISTRO == "CoreOS" ]]; then
-    systemctl stop docker
-fi
+stop_docker

--- a/scripts/enable.sh
+++ b/scripts/enable.sh
@@ -18,102 +18,44 @@
 
 set -eu
 set -o pipefail
-source ./dockerlib.sh
+script_dir=$(cd $(dirname $0); pwd)
+source $script_dir/dockerlib.sh
 
+signal_transitioning
 validate_distro
 
 IFS=$'\n\t'
 
-exec >> $LOG_FILE 2>&1
+exec >> $log_file 2>&1
 
 log "Enabling Docker"
+log "Using config: $config_path"
 
-config=$CONFIG_DIR/$CONFIG_FILE
-log "Using config: $config"
+if [[ $(install_only) == "false" ]]; then
+    restart_docker
+else
+    stop_docker 
+	signal_success
+	exit
+fi
 
-status=$STATUS_DIR/$STATUS_FILE
-
-cat $SCRIPT_DIR/running.status.json | sed s/@@DATE@@/$(date -u +%FT%TZ)/ > $status
-
-azureuser=$(grep -Eo '<UserName>.+</UserName>' /var/lib/waagent/ovf-env.xml | awk -F'[<>]' '{ print $3 }')
-
-if [ -n "$(cat $config | json_dump '["runtimeSettings"][0]["handlerSettings"]["publicSettings"]["composeup"]' 2>/dev/null )" ]; then
-    compose_up=$(cat $config | json_dump '["runtimeSettings"][0]["handlerSettings"]["publicSettings"]["composeup"]')
+if [ -n "$(cat $config_path | json_dump '["runtimeSettings"][0]["handlerSettings"]["publicSettings"]["composeup"]' 2>/dev/null )" ]; then
+    compose_up=$(cat $config_path | json_dump '["runtimeSettings"][0]["handlerSettings"]["publicSettings"]["composeup"]')
 else
     compose_up="false"
 fi
 
+log "Compose up is $compose_up"
+
 if [ "$compose_up" != "false" ]; then
-    log "composing:"
+    azureuser=$(grep -Eo '<UserName>.+</UserName>' /var/lib/waagent/ovf-env.xml | awk -F'[<>]' '{ print $3 }')
+    log "Composing:"
     echo $compose_up | yaml_dump
     mkdir -p "/home/$azureuser/compose"
     pushd "/home/$azureuser/compose"
     echo $compose_up | yaml_dump > ./docker-compose.yml
     docker-compose up -d
     popd
-else
-    log "No compose args, not starting anything"
 fi
 
-if [ -n "$(cat $config | json_val \
-    '["runtimeSettings"][0]["handlerSettings"]["publicSettings"]["installonly"]' \
-    2>/dev/null )" ]; then
-    install_only=$(cat $config | json_val \
-    '["runtimeSettings"][0]["handlerSettings"]["publicSettings"]["installonly"]')
-else
-    install_only="false"
-fi
-
-if [ $install_only == "true" ]; then
-    cat $SCRIPT_DIR/success.status.json | sed s/@@DATE@@/$(date -u +%FT%TZ)/ > $status
-    exit
-fi
-
-docker_dir=/etc/docker
-
-if [ ! -d $docker_dir ]; then
-    log "Creating $docker_dir"
-    mkdir $docker_dir
-fi
-
-thumb=$(cat $config | json_val \
-    '["runtimeSettings"][0]["handlerSettings"]["protectedSettingsCertThumbprint"]')
-cert=/var/lib/waagent/${thumb}.crt
-pkey=/var/lib/waagent/${thumb}.prv
-prot=$SCRIPT_DIR/prot.json
-
-cat $config | \
-    json_val '["runtimeSettings"][0]["handlerSettings"]["protectedSettings"]' | \
-    base64 -d | \
-    openssl smime  -inform DER -decrypt -recip $cert  -inkey $pkey > \
-    $prot
-
-log "Creating Certs"
-cat $prot | json_val '["ca"]' | base64 -d > $docker_dir/ca.pem
-cat $prot | json_val '["server-cert"]' | base64 -d > $docker_dir/server-cert.pem
-cat $prot | json_val '["server-key"]' | base64 -d > $docker_dir/server-key.pem
-rm $prot
-chmod 600 $docker_dir/*
-
-port=$(cat $config | json_val \
-    '["runtimeSettings"][0]["handlerSettings"]["publicSettings"]["dockerport"]')
-
-log "Docker port: $port"
-
-if [ $DISTRO == "Ubuntu" ]; then
-    log "Setting up /etc/default/docker"
-    cat <<EOF > /etc/default/docker
-DOCKER_OPTS="--tlsverify --tlscacert=$docker_dir/ca.pem --tlscert=$docker_dir/server-cert.pem --tlskey=$docker_dir/server-key.pem -H=0.0.0.0:$port"
-EOF
-
-    log "Starting Docker"
-    update-rc.d docker defaults
-    service docker restart
-elif [ $DISTRO == "CoreOS" ]; then
-    sed -i "s%ExecStart=.*%ExecStart=/usr/bin/docker --daemon --tlsverify --tlscacert=$docker_dir/ca.pem --tlscert=$docker_dir/server-cert.pem --tlskey=$docker_dir/server-key.pem -H=0.0.0.0:$port%" /etc/systemd/system/docker.service
-
-    systemctl daemon-reload
-    systemctl restart docker
-fi
-
-cat $SCRIPT_DIR/success.status.json | sed s/@@DATE@@/$(date -u +%FT%TZ)/ > $status
+signal_success

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,27 +18,29 @@
 
 set -eu
 set -o pipefail
-source ./dockerlib.sh
+script_dir=$(cd $(dirname $0); pwd)
+source $script_dir/dockerlib.sh
 
+signal_transitioning
 validate_distro
 
 IFS=$'\n\t'
-
-exec >> $LOG_FILE 2>&1
-status=$STATUS_DIR/$STATUS_FILE
-
-cat $SCRIPT_DIR/running.status.json | sed s/@@DATE@@/$(date -u +%FT%TZ)/ > $status
+exec >> $log_file 2>&1
 
 log "Installing Docker..."
 
-if [ $DISTRO == "Ubuntu" ]; then
+if [ $distro == "Ubuntu" ]; then
     wget -qO- https://get.docker.com/ | sh
-elif [ $DISTRO == "CoreOS" ]; then
+elif [ $distro == "CoreOS" ]; then
     log "Copy /usr/lib/systemd/system/docker.service --> /etc/systemd/system/"
     cp /usr/lib/systemd/system/docker.service /etc/systemd/system/
 fi
 
-log "Add user to docker group"
+# Install should not imply starting of the docker service, however in the Ubuntu install
+# case above, running Docker's install script will start the service.
+stop_docker
+
+log "Adding user to docker group"
 azureuser=$(grep -Eo '<UserName>.+</UserName>' /var/lib/waagent/ovf-env.xml | awk -F'[<>]' '{ print $3 }')
 sed -i -r "s/^docker:x:[0-9]+:$/&$azureuser/" /etc/group
 
@@ -46,7 +48,7 @@ log "Done installing Docker"
 
 log "Installing Docker Compose..."
 
-if [ $DISTRO == "CoreOS" ]; then
+if [ $distro == "CoreOS" ]; then
     COMPOSE_DIR=/opt/bin
     mkdir -p $compose_dir
 else
@@ -57,3 +59,54 @@ curl -L https://github.com/docker/compose/releases/download/1.2.0/docker-compose
 chmod +x $COMPOSE_DIR/docker-compose
 
 log "Done installing Docker Compose"
+
+log "Installing certificates"
+
+if [ ! -d $docker_dir ]; then
+    log "Creating $docker_dir"
+    mkdir $docker_dir
+fi
+
+thumb=$(cat $config_path | json_val \
+    '["runtimeSettings"][0]["handlerSettings"]["protectedSettingsCertThumbprint"]')
+cert=/var/lib/waagent/${thumb}.crt
+pkey=/var/lib/waagent/${thumb}.prv
+prot=$script_dir/prot.json
+
+cat $config_path | \
+    json_val '["runtimeSettings"][0]["handlerSettings"]["protectedSettings"]' | \
+    base64 -d | \
+    openssl smime  -inform DER -decrypt -recip $cert  -inkey $pkey > \
+    $prot
+
+log "Creating certificates in $docker_dir"
+
+cat $prot | json_val '["ca"]' | base64 -d > $docker_dir/ca.pem
+cat $prot | json_val '["server-cert"]' | base64 -d > $docker_dir/server-cert.pem
+cat $prot | json_val '["server-key"]' | base64 -d > $docker_dir/server-key.pem
+
+rm $prot
+chmod 600 $docker_dir/*
+
+log "Done installing certificates"
+
+log "Initializing docker command line arguments"
+
+port=$(cat $config_path | json_val \
+    '["runtimeSettings"][0]["handlerSettings"]["publicSettings"]["dockerport"]')
+
+log "Docker port: $port"
+
+if [ $distro == "Ubuntu" ]; then
+    log "Setting up /etc/default/docker"
+    cat <<EOF > /etc/default/docker
+DOCKER_OPTS="--tlsverify --tlscacert=$docker_dir/ca.pem --tlscert=$docker_dir/server-cert.pem --tlskey=$docker_dir/server-key.pem -H=0.0.0.0:$port"
+EOF
+    update-rc.d docker defaults
+elif [ $distro == "CoreOS" ]; then
+    log "Setting up /etc/systemd/system/docker.service"
+    sed -i "s%ExecStart=.*%ExecStart=/usr/bin/docker --daemon --tlsverify --tlscacert=$docker_dir/ca.pem --tlscert=$docker_dir/server-cert.pem --tlskey=$docker_dir/server-key.pem -H=0.0.0.0:$port%" /etc/systemd/system/docker.service
+    systemctl daemon-reload
+fi
+
+log "Done initializing docker command line arguments"


### PR DESCRIPTION
This change fixes the issue descibed in:
Docker certificate will be overwritten after rebooting #4

install.sh now creates certificates instead of enable.sh.  This change
also removes the install_only option which doesn't appear to have been
used by anything.

Because docker is now started by default on install with the official
Docker script, docker is now restarted at the end of installation to
pick up all configuration changes which occur after the Docker install
script is run.

Since restarting of docker occurs in both install.sh and enable.sh it
has been factored out into the shared library.