### PR TITLE
Pass io.Discard to exec(compose -d) to prevent crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ operation log of the extension at the
 ### Changelog
 
 ```
+# 1.0.1507110733 (2015-07-11)
+- Workaround for a bug caused from docker-compose to crash with error
+  'write /dev/stderr: broken pipe'
+
 # 1.0.1507101636 (2015-07-10)
 - Bug fix (gh#38). Blocking on install step instead of forking and running in
   background.

--- a/src/docker-extension/op_enable.go
+++ b/src/docker-extension/op_enable.go
@@ -110,7 +110,7 @@ func composeUp(d driver.DistroDriver, json map[string]interface{}) error {
 	}
 
 	compose := filepath.Join(d.DockerComposeDir(), composeBin)
-	return executil.ExecPipe(compose, "-p", composeProject, "-f", ymlPath, "up", "-d")
+	return executil.ExecPipeToFds(executil.Fds{Out: ioutil.Discard}, compose, "-p", composeProject, "-f", ymlPath, "up", "-d")
 }
 
 // installDockerCerts saves the configured certs to the specified dir

--- a/util/run-in-background.sh
+++ b/util/run-in-background.sh
@@ -10,4 +10,4 @@ set -eu
 # and yet still reports its progress through '.status' files to
 # the extension system.
 
-nohup ./bin/docker-extension $@ &
+nohup ./bin/docker-extension $@ > /var/log/nohup.log &


### PR DESCRIPTION
Fix the error`'write /dev/stderr: broken pipe'` issues caused by `docker-compose` by setting 1>/dev/null on its exec call.