### PR TITLE
Workaround for VMSS sequencing issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,11 @@ operation log of the extension at the
 ### Changelog
 
 ```
+# 1.0.1512020618 (2015-12-01)
+- Bumped docker-compose version from v1.4.1 to v1.5.1.
+- Added retry logic around installation as a mitigation for a VM scale set
+  issue.
+
 # 1.0.1510142311 (2015-10-14)
 - Configured docker-compose timeout to 15 minutes to prevent big images
   from failing to be pulled down intermittently due to network conditions.

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -41,7 +41,7 @@ func GetDriver(d distro.Info) (DistroDriver, error) {
 		} else if major < 15 {
 			return UbuntuUpstartDriver{}, nil
 		} else {
-			return UbuntuSystemdDriver{}, nil //TODO fix with systemd
+			return UbuntuSystemdDriver{}, nil
 		}
 	}
 


### PR DESCRIPTION
- Add retry logic around docker engine installation due to multiple
  extensions acquiring dpkg (apt-get) lock simulatenously instead of
  proper serialization.
- Bump docker-compose to 1.5.1