### PR TITLE
update compose to 1.6.2

### DIFF
--- a/op-enable.go
+++ b/op-enable.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	composeUrl         = "https://github.com/docker/compose/releases/download/1.5.1/docker-compose-Linux-x86_64"
+	composeUrl         = "https://github.com/docker/compose/releases/download/1.6.2/docker-compose-Linux-x86_64"
 	composeBin         = "docker-compose"
 	composeTimeoutSecs = 600
 

--- a/op-enable.go
+++ b/op-enable.go
@@ -250,6 +250,10 @@ func composeUp(d driver.DistroDriver, json map[string]interface{}, env map[strin
 	defer os.Unsetenv("COMPOSE_HTTP_TIMEOUT")
 	defer os.Unsetenv("DOCKER_CLIENT_TIMEOUT")
 
+	// set docker-compose.yml path to share directory with docker-compose container.
+	os.Setenv("COMPOSE_FILE", ymlPath)
+	defer os.Unsetenv("COMPOSE_FILE")
+
 	// set protected environment variables to be used in docker-compose
 	for k, v := range env {
 		log.Printf("Setting protected environment variable '%s'.", k)

--- a/op-enable.go
+++ b/op-enable.go
@@ -250,10 +250,6 @@ func composeUp(d driver.DistroDriver, json map[string]interface{}, env map[strin
 	defer os.Unsetenv("COMPOSE_HTTP_TIMEOUT")
 	defer os.Unsetenv("DOCKER_CLIENT_TIMEOUT")
 
-	// set docker-compose.yml path to share directory with docker-compose container.
-	os.Setenv("COMPOSE_FILE", ymlPath)
-	defer os.Unsetenv("COMPOSE_FILE")
-
 	// set protected environment variables to be used in docker-compose
 	for k, v := range env {
 		log.Printf("Setting protected environment variable '%s'.", k)


### PR DESCRIPTION
To support version 2 syntax of `docker-compose.yml`.