### PR TITLE
Use exec to redirect headless logs in enable op

### DIFF
--- a/doc/Maintainers-Guide.md
+++ b/doc/Maintainers-Guide.md
@@ -18,7 +18,7 @@ This will compile and create the extension handler zip package to `bundle/` dire
 ### 2. Upload the package
 
 Extension follows the semantic versioning [MAJOR].[MINOR].[PATCH]. The MAJOR/MINOR
-are stored in the `Makefile` and PATCH is the build date of the bundle in `yymmddHHMM`
+are stored in the `Makefile` and PATCH is the UTC build date of the bundle in `yymmddHHMM`
 format.
 
 * **Bump `MAJOR` if**: you are introducing breaking changes in the config schema

--- a/integration-test/test.sh
+++ b/integration-test/test.sh
@@ -8,10 +8,11 @@ readonly TEST_REGION="Brazil South"
 
 # supported images (add/update them as new major versions come out)
 readonly DISTROS=(
-	"2b171e93f07c4903bcad35bda10acf22__CoreOS-Beta-877.1.0" \
+	"2b171e93f07c4903bcad35bda10acf22__CoreOS-Stable-835.9.0" \
+	"b39f27a8b8c64d52b05eac6a62ebad85__Ubuntu-14_04_3-LTS-amd64-server-20151117-en-us-30GB" \
+	"b39f27a8b8c64d52b05eac6a62ebad85__Ubuntu-15_10-amd64-server-20160222-en-us-30GB" \
 	"5112500ae3b842c8b9c604889f8753c3__OpenLogic-CentOS-71-20150731" \
-	"b39f27a8b8c64d52b05eac6a62ebad85__Ubuntu-15_04-amd64-server-20151201-en-us-30GB" \
-	"b39f27a8b8c64d52b05eac6a62ebad85__Ubuntu-14_04_3-LTS-amd64-server-20151117-en-us-30GB" )
+	)
 
 # Test constants
 readonly SCRIPT_DIR=$(dirname $0)

--- a/scripts/run-in-background.sh
+++ b/scripts/run-in-background.sh
@@ -2,6 +2,11 @@
 set -eu
 readonly SCRIPT_DIR=$(dirname $0)
 
+# Script logs its output (stdout/stderr) simultaneously to a file
+# as waagent does not capture output of processes it starts.
+exec > >(tee -ia /var/log/azure-docker-extension-enable.log)
+exec 2>&1
+
 # This script kicks off the ./bin/docker-extension in the
 # background and disowns it with nohup. This is a workaround
 # for the 5-minute time limit for 'enable' step and 15-minute
@@ -53,4 +58,4 @@ write_status() {
 
 write_status
 set -x
-nohup $(readlink -f "$SCRIPT_DIR/../bin/docker-extension") $@ > /var/log/nohup.log &
+nohup $(readlink -f "$SCRIPT_DIR/../bin/docker-extension") $@ &


### PR DESCRIPTION
Fixes weird issue with CentOS where docker-exntesion stops
receiving output from `yum install` and eventually crashes.

Addresses #73.
