### PR TITLE
Bump docker-compose to 1.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ You can find various usages of this at the following gallery templates:
 
 ### Supported Linux Distributions
 
-- CoreOS
+- CoreOS 899 and higher
 - Ubuntu 13 and higher
 - CentOS 7.1 and higher
 - Red Hat Enterprise Linux (RHEL) 7.1 and higher
@@ -185,6 +185,10 @@ If you are going to open an issue, please provide these log files.
 ### Changelog
 
 ```
+# 1.1.1604142300 (2016-04-14)
+- Fix: docker v1.11 release has broken docker-compose 1.5 from pulling private images.
+  Upgrading to docker-compose 1.6.2 and dropping support for docker-engine <1.9.1 (gh#80)
+
 # 1.1.1602270800 (2016-02-28)
 - Fix: extension crash while collecting “yum install” output.
 

--- a/integration-test/test.sh
+++ b/integration-test/test.sh
@@ -12,7 +12,7 @@ readonly DOCKER_REMOTE_API_VERSION=1.20
 
 # supported images (add/update them as new major versions come out)
 readonly DISTROS=(
-	"2b171e93f07c4903bcad35bda10acf22__CoreOS-Stable-835.9.0" \
+	"2b171e93f07c4903bcad35bda10acf22__CoreOS-Stable-899.15.0" \
 	"2b171e93f07c4903bcad35bda10acf22__CoreOS-Alpha-970.1.0" \
 	"b39f27a8b8c64d52b05eac6a62ebad85__Ubuntu-14_04_3-LTS-amd64-server-20151117-en-us-30GB" \
 	"b39f27a8b8c64d52b05eac6a62ebad85__Ubuntu-15_10-amd64-server-20160222-en-us-30GB" \

--- a/op-enable.go
+++ b/op-enable.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	composeUrl         = "https://github.com/docker/compose/releases/download/1.5.1/docker-compose-Linux-x86_64"
+	composeUrl         = "https://github.com/docker/compose/releases/download/1.6.2/docker-compose-Linux-x86_64"
 	composeBin         = "docker-compose"
 	composeTimeoutSecs = 600
 


### PR DESCRIPTION
docker-engine release has broken the downstream yet again. When docker-compose 1.5 (released in Nov 2015) tries to pull private images from newly released docker-engine 1.11.0, it fails with "image not found" error because of the e-mail field removed from “docker login” file. (in other words, docker-engine broke docker-compose from 5 months ago). Details: #80.

As a solution, **bumping docker-compose to v1.6.2**, which supports docker-engine >=1.9.1. Although compose 1.7 is out, we cannot upgrade to that as CoreOS Stable feed (as of writing coreos-899) is using docker-1.9.1 and compose-1.7 requires docker-1.10. 

This will make the DockerExtension unsupported for older CoreOS stable releases that are still available on Azure (such as CoreOS-Stable-835). Therefore changing README to reflect that we support CoreOS 899 or higher.