### PR TITLE
compose-environment configuration key, better erros

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ this:
   is intended for starting a static set of bootstrap containers for monitoring,
   security or orchestrator agents. **Please do not manage your containers through
   this feature.** 
+* `compose-environment` (optional, JSON object) [Environment variables for docker-compose][compose-env].
+
+[compose-env]: https://docs.docker.com/compose/reference/envvars/
 
 A minimal simple configuration would be an empty json object (`{}`) or a more
 advanced one like this:
@@ -53,10 +56,14 @@ advanced one like this:
 			"image" : "memcached",
 			"ports" : ["11211:11211"]
 		},
-		"blog": {
+		"web": {
 			"image": "ghost",
 			"ports": ["80:2368"]
 		}
+	},
+	"compose-environment": {
+		"COMPOSE_PROJECT_NAME": "blog",
+		"COMPOSE_HTTP_TIMEOUT": "600"
 	}
 }
 ```
@@ -190,6 +197,11 @@ If you are going to open an issue, please provide these log files.
 ### Changelog
 
 ```
+# 1.1.1606092330 (2016-06-09)
+- Introduced “compose-environment” public configuration to pass additional unencrypted
+  environment variables to docker-compose for fine tuning. (gh#87, gh#89)
+- Better error messages for docker-compose failures indicating the log path. (gh#86)
+
 # 1.1.1604142300 (2016-04-14)
 - Fix: docker v1.11 release has broken docker-compose 1.5 from pulling private images.
   Upgrading to docker-compose 1.6.2 and dropping support for docker-engine <1.9.1 (gh#80)

--- a/handlersettings.go
+++ b/handlersettings.go
@@ -10,14 +10,15 @@ import (
 type publicSettings struct {
 	Docker      dockerEngineSettings   `json:"docker"`
 	ComposeJson map[string]interface{} `json:"compose"`
+	ComposeEnv  map[string]string      `json:"compose-environment"`
 }
 
 // protectedSettings is the type decoded and deserialized from protected
 // configuration section.
 type protectedSettings struct {
-	Certs       dockerCertSettings  `json:"certs"`
-	Login       dockerLoginSettings `json:"login"`
-	Environment map[string]string   `json:"environment"`
+	Certs               dockerCertSettings  `json:"certs"`
+	Login               dockerLoginSettings `json:"login"`
+	ComposeProtectedEnv map[string]string   `json:"environment"`
 }
 
 type dockerEngineSettings struct {

--- a/integration-test/extensionconfig/public.json
+++ b/integration-test/extensionconfig/public.json
@@ -7,10 +7,10 @@
 			]
 	},
 	"compose" : {
-		"env" : {
+		"envdump" : {
 			"image" : "busybox",
 			"volumes": ["/test:/test"],
-			"environment": ["SECRET_KEY"],
+			"environment": ["COMPOSE_PROJECT_NAME", "SECRET_KEY"],
 			"command": "/bin/sh -c 'env > /test/env.txt'"
 		},
 		"web" : { 
@@ -18,5 +18,8 @@
 			"restart" : "always",
 			"ports" : ["80:80"]
 		}
+	},
+	"compose-environment": {
+		"COMPOSE_PROJECT_NAME": "test"
 	}
 }

--- a/op-enable.go
+++ b/op-enable.go
@@ -139,8 +139,8 @@ func enable(he vmextension.HandlerEnvironment, d driver.DistroDriver) error {
 
 	// Compose Up
 	log.Printf("++ compose up")
-	if err := composeUp(d, settings.ComposeJson, settings.Environment); err != nil {
-		return fmt.Errorf("'compose up' failed: %v", err)
+	if err := composeUp(d, settings.ComposeJson, settings.ComposeEnv, settings.ComposeProtectedEnv); err != nil {
+		return fmt.Errorf("'docker-compose up' failed: %v. Check logs at %s.", err, filepath.Join(he.HandlerEnvironment.LogFolder, LogFilename))
 	}
 	log.Printf("-- compose up")
 	return nil


### PR DESCRIPTION
Commits for release `v1.1.1606092330`.

----

### Better error message for compose failures  

Refer users to the log message for more information.
Logging stdout/stderr here is quite difficult as it is free-form
and there are no guarantees around it such that it will not log
secret/sensitive data about the user’s workload and so on.

Fixes #86.

-------

### Introduce `compose-environment` configuration key  

`compose-environment` will allow users to fine tune non-secret
environment variables for docker-compose through extension configuration.
These can be timeout settings, project name and so on.

More: https://docs.docker.com/compose/reference/envvars/

Also updates integration-tests to validate added functionality.

Fixes #85.
Fixes #87.
