### PR TITLE
pkg/vmextension/status: atomic file write

### DIFF
--- a/pkg/vmextension/status/status_test.go
+++ b/pkg/vmextension/status/status_test.go
@@ -8,18 +8,13 @@ import (
 )
 
 func Test_NewStatus(t *testing.T) {
-	dir, err := ioutil.TempDir(os.TempDir(), "test")
+	dir, err := ioutil.TempDir("", "")
 	defer os.RemoveAll(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	s := NewStatus(StatusSuccess, "op", "msg")
-	if err := s.Save(dir, 2); err != nil {
-		t.Fatal(err)
-	}
-
-	// write once more to ensure truncation
 	if err := s.Save(dir, 2); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
If waagent reads .status in the middle of a partial write, it will
get malformed JSON. Therefore write status file into a $file.tmp.$RANDOM
path in the same directory and then move to $file atomically.

Fixes #100.

cc: @boumenot 