### PR TITLE
systemd: update ExecStart with dockerd and -H=unix://

### DIFF
--- a/pkg/dockeropts/systemd.go
+++ b/pkg/dockeropts/systemd.go
@@ -12,7 +12,7 @@ import (
 type SystemdUnitEditor struct{}
 
 func (e SystemdUnitEditor) ChangeOpts(contents, args string) (string, error) {
-	cmd := fmt.Sprintf("ExecStart=/usr/bin/docker %s", args)
+	cmd := fmt.Sprintf("ExecStart=/usr/bin/dockerd %s", args)
 	r := regexp.MustCompile("ExecStart=.*")
 
 	if r.FindString(contents) == "" {

--- a/pkg/dockeropts/systemd_test.go
+++ b/pkg/dockeropts/systemd_test.go
@@ -19,7 +19,7 @@ After=network.target docker.socket
 Requires=docker.socket
 
 [Service]
-ExecStart=/usr/bin/docker -d -H fd://
+ExecStart=/usr/bin/dockerd -H=fd://
 MountFlags=slave
 LimitNOFILE=1048576
 LimitNPROC=1048576
@@ -35,7 +35,7 @@ After=network.target docker.socket
 Requires=docker.socket
 
 [Service]
-ExecStart=/usr/bin/docker --tlsverify
+ExecStart=/usr/bin/dockerd --tlsverify
 MountFlags=slave
 LimitNOFILE=1048576
 LimitNPROC=1048576

--- a/pkg/dockeropts/upstart_test.go
+++ b/pkg/dockeropts/upstart_test.go
@@ -19,7 +19,7 @@ func TestUpstartEditor_UbuntuDefault(t *testing.T) {
 	in := `# Docker Upstart and SysVinit configuration file
 
 # Customize location of Docker binary (especially for development testing).
-#DOCKER="/usr/local/bin/docker"
+#DOCKER="/usr/local/bin/dockerd"
 
 # Use DOCKER_OPTS to modify the daemon startup options.
 #DOCKER_OPTS="--dns 8.8.8.8 --dns 8.8.4.4"
@@ -33,7 +33,7 @@ func TestUpstartEditor_UbuntuDefault(t *testing.T) {
 	expected := `# Docker Upstart and SysVinit configuration file
 
 # Customize location of Docker binary (especially for development testing).
-#DOCKER="/usr/local/bin/docker"
+#DOCKER="/usr/local/bin/dockerd"
 
 # Use DOCKER_OPTS to modify the daemon startup options.
 DOCKER_OPTS="-d --tlsverify"

--- a/pkg/driver/centos.go
+++ b/pkg/driver/centos.go
@@ -19,3 +19,11 @@ func (c CentOSDriver) UninstallDocker() error {
 }
 
 func (c CentOSDriver) DockerComposeDir() string { return "/usr/local/bin" }
+
+func (c CentOSDriver) BaseOpts() []string {
+	// centos socket activation is removed from get.docker.com installation script
+	// therefore we don't use -H=fd:// on centos. See more context here:
+	// - https://github.com/docker/docker/issues/23793
+	// - https://github.com/docker/docker/pull/24804
+	return []string{"-H=unix://"}
+}

--- a/pkg/driver/systemd_base.go
+++ b/pkg/driver/systemd_base.go
@@ -33,5 +33,5 @@ func (u systemdUnitOverwriteDriver) UpdateDockerArgs(args string) (bool, error) 
 }
 
 func (u systemdUnitOverwriteDriver) BaseOpts() []string {
-	return []string{"daemon", "-H=fd://"}
+	return []string{"-H=fd://"}
 }


### PR DESCRIPTION
- get.docker.com script has removed support for -H=fd:// on
  centos, therefore updating it to use -H=unix:// by default on
  centos.
- also switching to dockerd over 'docker daemon' in ExecStart of
  systemd unit files

Fixes #104.