### PR TITLE
Update changelog for v1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,14 @@ If you are going to open an issue, please provide these log files.
 ### Changelog
 
 ```
+# 1.2.0 (2016-08-19)
+- Fix: On CentOS start dockerd as -H=unix:// instead of -H=fd:// as get.docker.com
+  install script has removed socket activation. (gh#104)
+- Prefer 'dockerd' in systemd unit files over 'docker daemon'. docker-engine has
+  migrated to this. This is why we are releasing a minor version for the extension
+  this time and not a hotfix so that existing VMs don’t automatically get this and
+  old versions of docker will not work with dockerd.
+
 # 1.1.1606092330 (2016-06-09)
 - Introduced “compose-environment” public configuration to pass additional unencrypted
   environment variables to docker-compose for fine tuning. (gh#87, gh#85)

--- a/integration-test/test.sh
+++ b/integration-test/test.sh
@@ -13,11 +13,11 @@ readonly DOCKER_REMOTE_API_VERSION=1.20
 # supported images (add/update them as new major versions come out)
 readonly DISTROS=(
 	"2b171e93f07c4903bcad35bda10acf22__CoreOS-Stable-899.15.0" \
-	"2b171e93f07c4903bcad35bda10acf22__CoreOS-Alpha-970.1.0" \
+	"2b171e93f07c4903bcad35bda10acf22__CoreOS-Alpha-1122.0.0" \
 	"b39f27a8b8c64d52b05eac6a62ebad85__Ubuntu-14_04_3-LTS-amd64-server-20151117-en-us-30GB" \
-	"b39f27a8b8c64d52b05eac6a62ebad85__Ubuntu-15_10-amd64-server-20160222-en-us-30GB" \
 	"b39f27a8b8c64d52b05eac6a62ebad85__Ubuntu-16_04-LTS-amd64-server-20160516.1-en-us-30GB" \
 	"5112500ae3b842c8b9c604889f8753c3__OpenLogic-CentOS-71-20150731" \
+	"5112500ae3b842c8b9c604889f8753c3__OpenLogic-CentOS-72n-20160629"
 	)
 
 # Test constants


### PR DESCRIPTION
- Prepare for v1.2.0 release
- Update list of test images to cover newest coreos, remove EOLd
  ubuntu15.10 and add centos7.2n which has regressed recently.