### PR TITLE
Add support for CoreOS's rename

### DIFF
--- a/metadata/manifest.xml
+++ b/metadata/manifest.xml
@@ -5,7 +5,7 @@
   <!-- Caution: Ordering of elements in this document matters. -->
   <ProviderNameSpace>Microsoft.Azure.Extensions</ProviderNameSpace>
   <Type>DockerExtension</Type>
-  <Version>1.2.0</Version>
+  <Version>1.2.1</Version>
   <Label>Docker Extension for Linux</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -22,7 +22,7 @@ type DistroDriver interface {
 }
 
 func GetDriver(d distro.Info) (DistroDriver, error) {
-	if d.Id == "CoreOS" {
+	if d.Id == "CoreOS" || d.Id == "\"Container Linux by CoreOS\"" {
 		return CoreOSDriver{}, nil
 	} else if d.Id == "Ubuntu" {
 		parts := strings.Split(d.Release, ".")


### PR DESCRIPTION
The Azure/azure-docker-extension determines the *driver* to use based on the OS.  The OS is identified by parsing the INI file /etc/lsb-release.  The DISTRIB_ID of CoreOS recently changed from CoreOS to "Container Linux by CoreOS."  This PR adds support for the rename.