### PR TITLE
Update change log, bump version 1.2.2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,9 @@ If you are going to open an issue, please provide these log files.
 ### Changelog
 
 ```
+# 1.2.2 (2017-01-21)
+- Add suport for the CoreOS rename (gh#116).
+
 # 1.2.1 (2016-11-15) (released in Azure China only)
 - Add support for Azure China by modifying the download URLs to point to the
   mirrors hosted by mirror.azure.cn (gh#112)

--- a/metadata/manifest.xml
+++ b/metadata/manifest.xml
@@ -5,7 +5,7 @@
   <!-- Caution: Ordering of elements in this document matters. -->
   <ProviderNameSpace>Microsoft.Azure.Extensions</ProviderNameSpace>
   <Type>DockerExtension</Type>
-  <Version>1.2.1</Version>
+  <Version>1.2.2</Version>
   <Label>Docker Extension for Linux</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>


### PR DESCRIPTION
1.2.1 was released in China, but the manifest.xml version was never
bumped appropriately.  Bump the version 1.2.2, and update the change
log.