### PR TITLE
removing email from docker login parameters

### DIFF
--- a/op-enable.go
+++ b/op-enable.go
@@ -213,7 +213,6 @@ func loginRegistry(s dockerLoginSettings) error {
 	}
 	opts := []string{
 		"login",
-		"--email=" + s.Email,
 		"--username=" + s.Username,
 		"--password=" + s.Password,
 	}


### PR DESCRIPTION
https://docs.docker.com/engine/deprecated/, email flag is deprecated and removed in the latest docker engine version