### PR TITLE
change docker-engine to docker-ce for mooncake

### DIFF
--- a/op-enable.go
+++ b/op-enable.go
@@ -47,7 +47,7 @@ func enable(he vmextension.HandlerEnvironment, d driver.DistroDriver) error {
 	composeUrl := ""
 	switch settings.AzureEnv {
 		case "AzureChinaCloud":
-			dockerInstallCmd = "curl -sSL https://mirror.azure.cn/repo/install-docker-engine.sh | sh -s -- --mirror AzureChinaCloud"
+			dockerInstallCmd = "curl -sSL https://mirror.azure.cn/repo/install-docker-ce.sh | sh -s -- --mirror AzureChinaCloud"
 			composeUrl = composeUrlAzureChina
 		case "AzureCloud", "":
 			dockerInstallCmd = "curl -sSL https://get.docker.com/ | sh"


### PR DESCRIPTION
In mooncake, current docker-engine script does not work, docker has used new repo: docker-ce. In this PR, I changed the script to use https://mirror.azure.cn/docker-ce/ in mooncake. And https://mirror.azure.cn/docker-ce/ is only for mooncake VM, outside IP is forbidden.